### PR TITLE
Optimize simplified Chinese translation

### DIFF
--- a/src/main/resources/assets/mekanism_lasers/lang/zh_cn.json
+++ b/src/main/resources/assets/mekanism_lasers/lang/zh_cn.json
@@ -1,21 +1,21 @@
 {
-  "block.mekanism_lasers.laser_stopper": "激光挡块",
-  "block.mekanism_lasers.laser_splitter": "激光分光器",
+  "block.mekanism_lasers.laser_stopper": "激光阻断器",
+  "block.mekanism_lasers.laser_splitter": "激光分束器",
 
   "block.mekanism_lasers.basic_laser": "基础激光",
-  "block.mekanism_lasers.basic_toggleable_laser": "基础可切换激光",
+  "block.mekanism_lasers.basic_toggleable_laser": "基础可调节激光",
 
   "block.mekanism_lasers.advanced_laser": "高级激光",
-  "block.mekanism_lasers.advanced_toggleable_laser": "高级可切换激光",
+  "block.mekanism_lasers.advanced_toggleable_laser": "高级可调节激光",
 
   "block.mekanism_lasers.elite_laser": "精英激光",
-  "block.mekanism_lasers.elite_toggleable_laser": "精英可切换激光",
+  "block.mekanism_lasers.elite_toggleable_laser": "精英可调节激光",
 
   "block.mekanism_lasers.ultimate_laser": "终极激光",
-  "block.mekanism_lasers.ultimate_toggleable_laser": "终极可切换激光",
+  "block.mekanism_lasers.ultimate_toggleable_laser": "终极可调节激光",
 
   "block.mekanism_lasers.creative_laser": "创造激光",
-  "block.mekanism_lasers.creative_toggleable_laser": "创造可切换激光",
+  "block.mekanism_lasers.creative_toggleable_laser": "创造可调节激光",
 
   "block.mekanism_lasers.energy_storage_casing": "能量存储外壳",
   "block.mekanism_lasers.energy_storage_port": "能量存储端口",
@@ -24,21 +24,21 @@
   "block.mekanism_lasers.ore_generator": "矿石生成器",
   "block.mekanism_lasers.interface_block": "接口方块",
 
-  "item.mekanism_lasers.remote_control": "遥控",
+  "item.mekanism_lasers.remote_control": "遥控器",
 
   "container.mekanism_lasers.ore_generator": "矿石生成器",
   "container.mekanism_lasers.interface_block": "接口方块",
 
-  "description.mekanism.laser_stopper": "可以变成任何形状的方块，并且仍能阻挡激光",
+  "description.mekanism.laser_stopper": "可以变成任何方块的形状，并且仍然能够阻断激光",
   "description.mekanism.laser_splitter": "将激光一分为二",
   "description.mekanism.laser": "高度集中的光线 :D",
   "description.mekanism.laser_toggleable": "高度集中的光线；但可以打开/关闭 :D",
   "description.mekanism.ore_generator": "利用光将能量转化为矿石",
-  "description.mekanism.interface_block": "通过放置遥控器与可切换激光进行交互",
+  "description.mekanism.interface_block": "通过放置遥控器与可调节激光进行交互",
 
   "es.port.mode": "",
 
-  "item_group.mekanism_lasers": "通用机械激光",
+  "item_group.mekanism_lasers": "通用机械：激光",
 
   "gui.ore_generator.energy_per_ore": "每生产一枚矿石所消耗的能量"
 }

--- a/src/main/resources/assets/mekanism_lasers/lang/zh_cn.json
+++ b/src/main/resources/assets/mekanism_lasers/lang/zh_cn.json
@@ -3,19 +3,19 @@
   "block.mekanism_lasers.laser_splitter": "激光分束器",
 
   "block.mekanism_lasers.basic_laser": "基础激光",
-  "block.mekanism_lasers.basic_toggleable_laser": "基础可调节激光",
+  "block.mekanism_lasers.basic_toggleable_laser": "基础可切换激光",
 
   "block.mekanism_lasers.advanced_laser": "高级激光",
-  "block.mekanism_lasers.advanced_toggleable_laser": "高级可调节激光",
+  "block.mekanism_lasers.advanced_toggleable_laser": "高级可切换激光",
 
   "block.mekanism_lasers.elite_laser": "精英激光",
-  "block.mekanism_lasers.elite_toggleable_laser": "精英可调节激光",
+  "block.mekanism_lasers.elite_toggleable_laser": "精英可切换激光",
 
   "block.mekanism_lasers.ultimate_laser": "终极激光",
-  "block.mekanism_lasers.ultimate_toggleable_laser": "终极可调节激光",
+  "block.mekanism_lasers.ultimate_toggleable_laser": "终极可切换激光",
 
   "block.mekanism_lasers.creative_laser": "创造激光",
-  "block.mekanism_lasers.creative_toggleable_laser": "创造可调节激光",
+  "block.mekanism_lasers.creative_toggleable_laser": "创造可切换激光",
 
   "block.mekanism_lasers.energy_storage_casing": "能量存储外壳",
   "block.mekanism_lasers.energy_storage_port": "能量存储端口",
@@ -33,8 +33,8 @@
   "description.mekanism.laser_splitter": "将激光一分为二",
   "description.mekanism.laser": "高度集中的光线 :D",
   "description.mekanism.laser_toggleable": "高度集中的光线；但可以打开/关闭 :D",
-  "description.mekanism.ore_generator": "利用光将能量转化为矿石",
-  "description.mekanism.interface_block": "通过放置遥控器与可调节激光进行交互",
+  "description.mekanism.ore_generator": "利用激光将能量转化为矿石",
+  "description.mekanism.interface_block": "通过放置遥控器与可切换激光进行交互",
 
   "es.port.mode": "",
 


### PR DESCRIPTION
Fix the incorrect translation of "description.mekanism.laser_stopper".And modified some of the inappropriate translations.Can I use "通用机械：激光" as the simplified Chinese name for this mod?It means "Mekanism:lasers".